### PR TITLE
Build and push image on merge

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -1,0 +1,32 @@
+name: Build and push test image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: eu-west-2
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push testing image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/DocAppPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/DocAppPage.java
@@ -10,7 +10,6 @@ public class DocAppPage extends BasePage {
 
     By idToken = By.id("user-info-phone-number");
 
-
     public void enterPayLoad(String jsonPayLoad) {
         driver.findElement(payloadInputField).sendKeys(jsonPayLoad);
     }

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export AWS_PROFILE=di-orchestration-build-admin
+aws sso login
+aws cloudformation update-stack \
+  --region eu-west-2 \
+  --stack-name="test-container-stack" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --template-body file://template.yaml \
+  --tags Key=Product,Value='GOV.UK Sign In' \
+         Key=System,Value=Orchestration \
+         Key=Environment,Value=Build \
+         Key=Owner,Value='di-orchestration@digital.cabinet-office.gov.uk' \
+         Key=Respository,Value='govuk-one-login/orchestration-acceptance-tests'

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1,0 +1,114 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Stack to create a ECR holding the container image for pipeline acceptance tests
+
+Resources:
+  ECR:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: pipeline-test-image
+      ImageTagMutability: MUTABLE
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Retain 10 untagged images",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+      RepositoryPolicyText:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAccountToPull
+            Effect: Allow
+            Principal: "*"
+            Action:
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:BatchGetImage"
+              - "ecr:DescribeImages"
+              - "ecr:DescribeRepositories"
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:GetLifecyclePolicy"
+              - "ecr:GetLifecyclePolicyPreview"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:ListImages"
+            Condition:
+              StringEquals:
+                "aws:PrincipalOrgID":
+                  - o-pjzf8d99ys
+                  - o-dpp53lco28
+
+  GitHubActionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Principal:
+              Federated: !ImportValue GitHubIdentityProviderArn
+            Condition:
+              StringLike:
+                "token.actions.githubusercontent.com:sub":
+                  - !Sub "repo:govuk-one-login/orchestration-acceptance-tests*ref:refs/heads/main"
+
+  TestRunnerImageRepositoryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName:
+        Fn::Join:
+          - "-"
+          - - !Ref AWS::StackName
+            - "TestRunnerImageRepositoryPolicy"
+            - Fn::Select:
+                - 4
+                - Fn::Split:
+                    - "-"
+                    - Fn::Select:
+                        - 2
+                        - Fn::Split:
+                            - "/"
+                            - Ref: AWS::StackId
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Sid: ListImagesInRepository
+            Action:
+              - "ecr:ListImages"
+            Resource:
+              - !GetAtt ECR.Arn
+          - Effect: Allow
+            Sid: ManageRepositoryContents
+            Action:
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:DescribeRepositories"
+              - "ecr:ListImages"
+              - "ecr:DescribeImages"
+              - "ecr:BatchGetImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"
+              - "ecr:PutImage"
+            Resource:
+              - !GetAtt ECR.Arn
+          - Effect: "Allow"
+            Sid: "AccessToECR"
+            Action:
+              - "ecr:GetAuthorizationToken"
+            Resource: "*"
+      Roles:
+        - !Ref GitHubActionsRole


### PR DESCRIPTION
- Set up infrastructure
    - ECR for test images
    - Role to allow Github to push to ECR
- Action to build image and push to ECR


Tested with a slightly modified config: https://github.com/govuk-one-login/orchestration-acceptance-tests/actions/runs/9406159732
As documented: https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3054010402/How+to+run+tests+against+your+deployed+application+in+a+SAM+deployment+pipeline