### PR TITLE
ATO-1133: enable running with local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ export AWS_PROFILE=di-orchestration-build-admin
 aws sso login
 ```
 
-You can then run `./run-local.sh`
+You can then run `./run-local.sh`.
+
+## Running locally with local environment
+Prerequisites:
+- An account on build (go to https://rp-build.build.stubs.account.gov.uk/ to make one)
+- Docker
+- Docker Desktop v4.25+, with `Use Rosetta for x86_64/amd64 emulation on Apple Silicon` turned on in settings
+
+Copy the `.env.sample` file to `.env` and add your credentials.
+
+You can then run `./local-env/run-local-env.sh`. This will run the tests with your own environment variables.
 
 ## Running in the pipeline
 A GitHub action builds the container image and pushes it to an ECR repository in the Build account upon push to main.

--- a/local-env/local-env.Dockerfile
+++ b/local-env/local-env.Dockerfile
@@ -1,0 +1,13 @@
+FROM selenium/standalone-chrome:125.0-20240517
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y openjdk-17-jdk awscli && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+COPY . /test
+RUN sudo chmod -R a+rwx /test && sudo mv /test/local-env/run-tests-local-env.sh /run-tests-local-env.sh
+WORKDIR /test
+RUN /test/gradlew -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64 clean build :acceptance-tests:compileTestJava -x :acceptance-tests:test
+WORKDIR /
+
+CMD ["/run-tests-local-env.sh"]

--- a/local-env/run-local-env.sh
+++ b/local-env/run-local-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build . -t orchestration-acceptance-test --file local-env/local-env.Dockerfile
+docker run orchestration-acceptance-test

--- a/local-env/run-tests-local-env.sh
+++ b/local-env/run-tests-local-env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function get_env_vars() {
+  set -a
+  source ./.env
+  set +a
+}
+
+cd /test
+
+# Start the selenium server
+/opt/bin/entry_point.sh &
+
+get_env_vars
+
+TEST_EXIT_CODE=0
+./gradlew -Dorg.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64 cucumber || TEST_EXIT_CODE=$?
+
+cp /test/acceptance-tests/target/cucumber-report/report.json ${TEST_REPORT_ABSOLUTE_DIR:-/test}/report.json
+
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
## What?
Adds a set of scripts to run the acceptance tests with local env variables (defined in a `.env` file).
Also renames the current scripts to distinguish them.

## Why?
To run with the build environment variables, you need to be on the VPN and have AWS access to build. The only thing it gets from build is some credentials for a valid user in build, but we can also just define these locally. A test engineer needs to be able to run these tests locally, but doesn't have AWS access. 

## How to review:
1. Code review
2. I have can run both scripts (build-env and local-env), and this docker image builds successfully