### PR TITLE
ATO-1310: add test for max age feature

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/RpStubPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/RpStubPage.java
@@ -8,11 +8,20 @@ public class RpStubPage extends BasePage {
         waitForThisText("Request Object");
     }
 
-    public void selectRpOptionsByIdAndContinue(String opts) {
-        if (!opts.isEmpty() && !opts.equalsIgnoreCase("default")) {
-            String ids[] = opts.split(",");
-            for (String id : ids) {
+    public void selectRpOptionsByIdAndContinue(String toggleOptions, String valueOptions) {
+        if (!toggleOptions.isEmpty() && !toggleOptions.equalsIgnoreCase("default")) {
+            String optionIds[] = toggleOptions.split(",");
+            for (String id : optionIds) {
                 driver.findElement(By.id(id)).click();
+            }
+        }
+        if (!valueOptions.isEmpty() && !valueOptions.equalsIgnoreCase("default")) {
+            String options[] = valueOptions.split(",");
+            for (String option : options) {
+                String[] optionStrings = option.split("=");
+                String optionId = optionStrings[0];
+                String optionValue = optionStrings[1];
+                driver.findElement(By.id(optionId)).sendKeys(optionValue);
             }
         }
         findAndClickContinue();

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -9,9 +9,17 @@ public class RpStubStepDef extends BasePage {
     RpStubPage rpStubPage = new RpStubPage();
 
     @When("the user comes from the stub relying party with options: {string}")
-    public void theExistingUserVisitsTheStubRelyingParty(String options) {
+    public void theExistingUserVisitsTheStubRelyingParty(String toggleOptions) {
         rpStubPage.goToRpStub();
-        rpStubPage.selectRpOptionsByIdAndContinue(options);
+        rpStubPage.selectRpOptionsByIdAndContinue(toggleOptions, "default");
+        setAnalyticsCookieTo(false);
+    }
+
+    @When("the user comes from the stub relying party with options: {string} and {string}")
+    public void theExistingUserVisitsTheStubRelyingPartyAndSetsValueOptions(
+            String toggleOptions, String valueOptions) {
+        rpStubPage.goToRpStub();
+        rpStubPage.selectRpOptionsByIdAndContinue(toggleOptions, valueOptions);
         setAnalyticsCookieTo(false);
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/authentication.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/authentication.feature
@@ -22,3 +22,15 @@ Feature: Authentication
     When the user closes and reopens their browser
     And the user comes from the stub relying party with options: "2fa-off"
     Then the user is taken to the "Create your GOV.UK One Login or sign in" page
+
+  Scenario: User is logged out when max-age enabled
+    Given the user comes from the stub relying party with options: "2fa-off"
+    Then the user is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When user enters "TEST_USER_EMAIL" email address
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is returned to the service
+    When the user comes from the stub relying party with options: "2fa-off" and "max-age=0"
+    Then the user is taken to the "Create your GOV.UK One Login or sign in" page


### PR DESCRIPTION
## What?
Adds a scenario for an RP using max age. In setting `max-age=0` in the stub on the second login attempt, we expect the user to be signed out.

I have set `MaxAgeEnabled` to `True` for the client `relying-party-stub-build-acceptance-test` in the `build-client-registry` table so that this scenario can be tested.

## Why?
So we have an acceptance test for the new `max-age` feature, which is currently in development.