### PR TITLE
BAU: Remove unused dependencies to resolve vulnerabilities

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -23,10 +23,8 @@ dependencies {
                        "io.cucumber:cucumber-junit:${dependencyVersions.cucumber_version}",
                        "org.seleniumhq.selenium:selenium-java:${dependencyVersions.selenium_java_version}",
                        "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
-                       "commons-codec:commons-codec:1.20.0",
-                       "io.github.cdimascio:java-dotenv:5.2.2"
+                       "commons-codec:commons-codec:1.20.0"
 
-    testImplementation group: 'com.deque', name: 'axe-selenium', version:"${dependencyVersions.axe_version}"
     testImplementation group: 'org.json', name: 'json', version:"${dependencyVersions.json_version}"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}"


### PR DESCRIPTION
## What?

- remove references to axe-selenium and java-dotenv as these introduce transitive dependencies with vulnerabilities
- these packages are included in `build.gradle` but are not used anywhere in the project.

## Why?

- dependabot notified us of vulnerabilities in [org.apache.commons:commons-lang3 3.4](https://github.com/govuk-one-login/orchestration-acceptance-tests/security/dependabot/3) (introduced via axe-selenium) and [org.jetbrains.kotlin:kotlin-stdlib 1.4.0](https://github.com/govuk-one-login/orchestration-acceptance-tests/security/dependabot/2) (introduced via java-dotenv).