### PR TITLE
BAU: Skip passkey prompt if prompted

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeyPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/CreatePasskeyPage.java
@@ -1,0 +1,15 @@
+package uk.gov.di.test.pages;
+
+import org.openqa.selenium.By;
+
+public class CreatePasskeyPage extends BasePage {
+
+    private final By skipButton = By.xpath("//button[contains(text(), 'Skip for now')]");
+    public static final String PATH = "/create-passkey";
+
+    public void skipPasskeyPrompt() {
+        if (driver.getCurrentUrl().contains(PATH)) {
+            driver.findElement(skipButton).click();
+        }
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -5,6 +5,7 @@ import io.cucumber.java.en.When;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CheckYourPhonePage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
+import uk.gov.di.test.pages.CreatePasskeyPage;
 import uk.gov.di.test.pages.EnterYourEmailAddressToSignInPage;
 import uk.gov.di.test.pages.EnterYourPasswordPage;
 
@@ -14,6 +15,7 @@ public class LoginStepDef extends BasePage {
     public EnterYourEmailAddressToSignInPage enterYourEmailAddressToSignInPage =
             new EnterYourEmailAddressToSignInPage();
     public CreateOrSignInPage createOrSignInPage = new CreateOrSignInPage();
+    public CreatePasskeyPage createPasskeyPage = new CreatePasskeyPage();
 
     @When("the user selects sign in")
     public void theUserSelectsSignIn() throws InterruptedException {
@@ -34,5 +36,10 @@ public class LoginStepDef extends BasePage {
     @When("the user enters the six digit security code from their phone")
     public void theUserEntersTheirPhoneCode() {
         checkYourPhonePage.enterCodeAndContinue(System.getenv().get("TEST_USER_PHONE_OTP"));
+    }
+
+    @And("the user skips passkey prompt if present")
+    public void userSkipsPasskey() {
+        createPasskeyPage.skipPasskeyPrompt();
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/identity.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/identity.feature
@@ -9,6 +9,7 @@ Feature: Identity
     When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user enters the six digit security code from their phone
+    And the user skips passkey prompt if present
     Then the user is taken to the "IPV Stub Form" page
     When the user clicks the continue button
     Then the user is returned to the service with extended timeout


### PR DESCRIPTION
## What?
We would like to skip passkey prompts if they appear during our acceptance tests

## Why?
We don't really care about passkeys, and adding any logic here would tightly couple us to Auth's passkeys implementation. We also aim to sub auth eventually, so we don't want anything permanent here

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.