### PR TITLE
ATO-2774 add documentation of existing acceptance test clients

### DIFF
--- a/test-clients-build/README.md
+++ b/test-clients-build/README.md
@@ -1,0 +1,7 @@
+# Acceptance test clients used in build
+
+These are the configurations that the acceptance tests expect to be in DynamoDB, but this folder is not the source of truth.
+
+| ClientID                         | ClientName                               | Description                   |
+|:---------------------------------|:-----------------------------------------|:------------------------------|
+| Ykg9fGyY76On4e8tPvFabK5BIl65EkGH | relying-party-stub-build-acceptance-test | Legacy acceptance test client |

--- a/test-clients-build/build-Ykg9fGyY76On4e8tPvFabK5BIl65EkGH.json
+++ b/test-clients-build/build-Ykg9fGyY76On4e8tPvFabK5BIl65EkGH.json
@@ -1,0 +1,64 @@
+{
+ "ClientID": "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH",
+ "BackChannelLogoutUri": "https://acceptance-test-rp-build.build.stubs.account.gov.uk/backchannel-logout",
+ "Claims": [
+  "https://vocab.account.gov.uk/v1/coreIdentityJWT",
+  "https://vocab.account.gov.uk/v1/passport",
+  "https://vocab.account.gov.uk/v1/address",
+  "https://vocab.account.gov.uk/v1/drivingPermit",
+  "https://vocab.account.gov.uk/v1/returnCode",
+  "https://vocab.account.gov.uk/v1/inheritedIdentityJWT"
+ ],
+ "ClientLoCs": [
+  "P0",
+  "P1",
+  "P2",
+  "P3"
+ ],
+ "ClientName": "relying-party-stub-build-acceptance-test",
+ "ClientType": "web",
+ "Contacts": [
+  "contact+relying-party-stub-build-acceptance-test@example.com"
+ ],
+ "CookieConsentShared": 1,
+ "IdentityVerificationSupported": 1,
+ "MaxAgeEnabled": true,
+ "OneLoginService": false,
+ "PostLogoutRedirectUrls": [
+  "https://acceptance-test-rp-build.build.stubs.account.gov.uk/signed-out",
+  "http://localhost:8080/signed-out",
+  "https://rp-build.build.stubs.account.gov.uk/signed-out"
+ ],
+ "PublicKey": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuhGhL42Zl3SnI14pc+zB4c87YOuKGaeCyA2abK5Mw7kqsDQGSaHJLR3GQxVHgctgjoNpl6zDpWfgdNcRn8w5VwrxwypCtLfNL57g/tuojgsSkWnnONtEZ/BNwiOqQ/g8ZSE2rrI2LefQMObJrEPhc2E7kPRWanbkzERhpX2DJf077XWQZPV7j08/NDukYz2MHfvyojN9MWtXWIVtPfMlfOoxLd9uO7p8pDQrS7TtBFxkkt6//YWMihcbrgPHMtwLTSziIVlUmbpSaKHRPc7o54TcGnIAOunk5hvjAZFUdHpEI81Ow2Pg5F0S/EqlWU3kUlzPykyNAlRVklqP9NNCfwIDAQAB",
+ "RedirectUrls": [
+  "https://acceptance-test-rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback",
+  "http://localhost:8080/oidc/authorization-code/callback",
+  "https://rp-build.build.stubs.account.gov.uk/oidc/authorization-code/callback"
+ ],
+ "Scopes": [
+  "openid",
+  "email",
+  "phone",
+  "wallet-subject-id",
+  "am"
+ ],
+ "SectorIdentifierUri": "https://acceptance-test-rp-build.build.stubs.account.gov.uk",
+ "ServiceType": "MANDATORY",
+ "SubjectType": "pairwise",
+ "TestClient": 1,
+ "TestClientEmailAllowlist": [
+  "^perftest\\w+@digital\\.cabinet-office\\.gov\\.uk$",
+  "^auth-test-user-[a-z][a-z]-[\\d]?[\\d]?[\\d]@digital\\.cabinet-office\\.gov\\.uk$",
+  "a@b.com",
+  "graham.osifo1@digital.cabinet-office.gov.uk",
+  "graham.auth.app@digital.cabinet-office.gov.uk",
+  "di-authentication-tech+varying-existing-user-journeys-account@digital.cabinet-office.gov.uk",
+  "^auth-test-user-pipeline-[\\d]?[\\d]?[\\d]@digital\\.cabinet-office\\.gov\\.uk$",
+  "^auth-test-user-local-[\\d]?[\\d]?[\\d]@digital\\.cabinet-office\\.gov\\.uk$",
+  "^auth-test-user-pipeline-[a-z][a-z]-[\\d]?[\\d]?[\\d]@digital\\.cabinet-office\\.gov\\.uk$",
+  "^test-user\\+[a-z]+-\\d+-\\d+@test\\.null\\.local$",
+  "^test-user\\+build-[\\w\\d-]+\\@test\\.null\\.local$",
+  "^test-user\\+build-\\d+-\\d+@test\\.null\\.local$",
+  "^orch-test-user\\d*@digital.cabinet-office.gov.uk$"
+ ]
+}


### PR DESCRIPTION
## What?

Add documentation of the existing client configurations used in the acceptance tests.

## Why?

We want to test a wider variety of configurations; we'll start by documenting what's there already and later add new configurations.